### PR TITLE
as - HelpRequest Controller and Tests with basic GET and POST request functionality

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -46,14 +46,10 @@ public class HelpRequestController extends ApiController {
             @ApiParam("In-person table or Zoom breakout room (table or breakoutroom)") @RequestParam String tableOrBreakoutRoom,
             @ApiParam("Time (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("localDateTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime requestTime,
             @ApiParam("Explanation of issue") @RequestParam String explanation,
-            @ApiParam("Whether issue has been resolved(true/false)") @RequestParam boolean solved)
-
-            throws JsonProcessingException {
+            @ApiParam("Whether issue has been resolved(true/false)") @RequestParam boolean solved){
 
         // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
         // See: https://www.baeldung.com/spring-date-parameters
-
-        log.info("requestTime={}", requestTime);
 
         HelpRequest helpRequest = new HelpRequest();
         helpRequest.setRequesterEmail(requesterEmail);

--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -44,7 +44,7 @@ public class HelpRequestController extends ApiController {
             @ApiParam("Email of user making request") @RequestParam String requesterEmail,
             @ApiParam("ID of team") @RequestParam String teamId,
             @ApiParam("In-person table or Zoom breakout room (table or breakoutroom)") @RequestParam String tableOrBreakoutRoom,
-            @ApiParam("time (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("localDateTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime requestTime,
+            @ApiParam("Time (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("localDateTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime requestTime,
             @ApiParam("Explanation of issue") @RequestParam String explanation,
             @ApiParam("Whether issue has been resolved(true/false)") @RequestParam boolean solved)
 

--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -1,0 +1,72 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+@Api(description = "HelpRequest")
+@RequestMapping("/api/helprequest")
+@RestController
+@Slf4j
+public class HelpRequestController extends ApiController {
+
+    @Autowired
+    HelpRequestRepository helpRequestRepository;
+
+    @ApiOperation(value = "List all help requests")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<HelpRequest> all() {
+        Iterable<HelpRequest> requests = helpRequestRepository.findAll();
+        return requests;
+    }
+
+    @ApiOperation(value = "Create a new help request")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PostMapping("/post")
+    public HelpRequest postHelpRequest(
+            @ApiParam("Email of user making request") @RequestParam String requesterEmail,
+            @ApiParam("ID of team") @RequestParam String teamId,
+            @ApiParam("In-person table or Zoom breakout room (table or breakoutroom)") @RequestParam String tableOrBreakoutRoom,
+            @ApiParam("time (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("localDateTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime requestTime,
+            @ApiParam("Explanation of issue") @RequestParam String explanation,
+            @ApiParam("Whether issue has been resolved(true/false)") @RequestParam boolean solved)
+
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        log.info("requestTime={}", requestTime);
+
+        HelpRequest helpRequest = new HelpRequest();
+        helpRequest.setRequesterEmail(requesterEmail);
+        helpRequest.setTeamId(teamId);
+        helpRequest.setTableOrBreakoutRoom(tableOrBreakoutRoom);
+        helpRequest.setRequestTime(requestTime);
+        helpRequest.setExplanation(explanation);
+        helpRequest.setSolved(solved);
+
+        HelpRequest savedHelpRequest = helpRequestRepository.save(helpRequest);
+
+        return savedHelpRequest;
+    }
+
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -38,7 +38,7 @@ public class HelpRequestController extends ApiController {
     }
 
     @ApiOperation(value = "Create a new help request")
-    @PreAuthorize("hasRole('ROLE_USER')")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
     public HelpRequest postHelpRequest(
             @ApiParam("Email of user making request") @RequestParam String requesterEmail,

--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -21,8 +21,8 @@ import lombok.Builder;
 public class HelpRequest {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-
     private long id;
+    
     private String requesterEmail;
     private String teamId;
     private String tableOrBreakoutRoom;

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -1,0 +1,318 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = HelpRequestController.class)
+@Import(TestConfig.class)
+public class HelpRequestControllerTests extends ControllerTestCase {
+
+        @MockBean
+        HelpRequestRepository helpRequestRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Authorization tests for /api/helprequest/admin/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/helprequest/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/helprequest/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/helprequest?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        // Authorization tests for /api/helprequest/post
+        // (Perhaps should also have these for put and delete)
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/helprequest/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/helprequest/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        // // Tests with mocks for database actions
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+                LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                UCSBDate ucsbDate = UCSBDate.builder()
+                                .name("firstDayOfClasses")
+                                .quarterYYYYQ("20222")
+                                .localDateTime(ldt)
+                                .build();
+
+                when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.of(ucsbDate));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/helprequest?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(helpRequestRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(ucsbDate);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/helprequest?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(helpRequestRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("UCSBDate with id 7 not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_helprequest() throws Exception {
+
+                // arrange
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                UCSBDate ucsbDate1 = UCSBDate.builder()
+                                .name("firstDayOfClasses")
+                                .quarterYYYYQ("20222")
+                                .localDateTime(ldt1)
+                                .build();
+
+                LocalDateTime ldt2 = LocalDateTime.parse("2022-03-11T00:00:00");
+
+                UCSBDate ucsbDate2 = UCSBDate.builder()
+                                .name("lastDayOfClasses")
+                                .quarterYYYYQ("20222")
+                                .localDateTime(ldt2)
+                                .build();
+
+                ArrayList<UCSBDate> expectedDates = new ArrayList<>();
+                expectedDates.addAll(Arrays.asList(ucsbDate1, ucsbDate2));
+
+                when(helpRequestRepository.findAll()).thenReturn(expectedDates);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/helprequest/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(helpRequestRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedDates);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_ucsbdate() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                UCSBDate ucsbDate1 = UCSBDate.builder()
+                                .name("firstDayOfClasses")
+                                .quarterYYYYQ("20222")
+                                .localDateTime(ldt1)
+                                .build();
+
+                when(helpRequestRepository.save(eq(ucsbDate1))).thenReturn(ucsbDate1);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/helprequest/post?name=firstDayOfClasses&quarterYYYYQ=20222&localDateTime=2022-01-03T00:00:00")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(helpRequestRepository, times(1)).save(ucsbDate1);
+                String expectedJson = mapper.writeValueAsString(ucsbDate1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_a_date() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                UCSBDate ucsbDate1 = UCSBDate.builder()
+                                .name("firstDayOfClasses")
+                                .quarterYYYYQ("20222")
+                                .localDateTime(ldt1)
+                                .build();
+
+                when(helpRequestRepository.findById(eq(15L))).thenReturn(Optional.of(ucsbDate1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/helprequest?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(helpRequestRepository, times(1)).findById(15L);
+                verify(helpRequestRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBDate with id 15 deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_ucsbdate_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(helpRequestRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/helprequest?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(helpRequestRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBDate with id 15 not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_ucsbdate() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+                LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
+
+                UCSBDate ucsbDateOrig = UCSBDate.builder()
+                                .name("firstDayOfClasses")
+                                .quarterYYYYQ("20222")
+                                .localDateTime(ldt1)
+                                .build();
+
+                UCSBDate ucsbDateEdited = UCSBDate.builder()
+                                .name("firstDayOfFestivus")
+                                .quarterYYYYQ("20232")
+                                .localDateTime(ldt2)
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(ucsbDateEdited);
+
+                when(helpRequestRepository.findById(eq(67L))).thenReturn(Optional.of(ucsbDateOrig));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/helprequest?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(helpRequestRepository, times(1)).findById(67L);
+                verify(helpRequestRepository, times(1)).save(ucsbDateEdited); // should be saved with correct user
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_ucsbdate_that_does_not_exist() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                UCSBDate ucsbEditedDate = UCSBDate.builder()
+                                .name("firstDayOfClasses")
+                                .quarterYYYYQ("20222")
+                                .localDateTime(ldt1)
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(ucsbEditedDate);
+
+                when(helpRequestRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/helprequest?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(helpRequestRepository, times(1)).findById(67L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBDate with id 67 not found", json.get("message"));
+
+        }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -130,7 +130,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                                 .tableOrBreakoutRoom("table")
                                 .requestTime(ldt)
                                 .explanation("test")
-                                .solved(false)
+                                .solved(true)
                                 .build();
 
                 when(helpRequestRepository.save(eq(helpRequest))).thenReturn(helpRequest);
@@ -143,7 +143,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                                 "&tableOrBreakoutRoom=table" +
                                 "&localDateTime=2022-01-03T00:00:00" +
                                 "&explanation=test" +
-                                "&solved=false")
+                                "&solved=true")
                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -121,27 +121,35 @@ public class HelpRequestControllerTests extends ControllerTestCase {
         @Test
         public void an_admin_user_can_post_a_new_helprequest() throws Exception {
                 // arrange
+                
+                LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
 
-                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
-
-                HelpRequest helpRequest1 = HelpRequest.builder()
+                HelpRequest helpRequest = HelpRequest.builder()
                                 .requesterEmail("cgaucho@ucsb.edu")
-                                .teamId("4")
+                                .teamId("team4")
                                 .tableOrBreakoutRoom("table")
-                                .requestTime(ldt1)
-                                .explanation("testing")
+                                .requestTime(ldt)
+                                .explanation("test")
                                 .solved(false)
                                 .build();
-                when(helpRequestRepository.save(eq(helpRequest1))).thenReturn(helpRequest1);
+
+                when(helpRequestRepository.save(eq(helpRequest))).thenReturn(helpRequest);
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                post("/api/helprequest/post?explanation=testing&localDateTime=2022-01-03T00%3A00%3A00&requesterEmail=cgaucho%40ucsb.edu&solved=false&tableOrBreakoutRoom=table&teamId=4"))
+                                post("/api/helprequest/post?" +
+                                "requesterEmail=cgaucho@ucsb.edu" +
+                                "&teamId=team4" +
+                                "&tableOrBreakoutRoom=table" +
+                                "&localDateTime=2022-01-03T00:00:00" +
+                                "&explanation=test" +
+                                "&solved=false")
+                                .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
                 // assert
-                verify(helpRequestRepository, times(1)).save(helpRequest1);
-                String expectedJson = mapper.writeValueAsString(helpRequest1); 
+                verify(helpRequestRepository, times(1)).save(helpRequest);
+                String expectedJson = mapper.writeValueAsString(helpRequest);
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
         }


### PR DESCRIPTION
# Overview

Adds a GET /all and POST (create single entry) requests to HelpRequest, and their respective tests. Functionality can be seen by using swagger-ui and selecting HelpRequestController.

# Issues Addressed

Fixes issue #10 