### PR TITLE
nw - added full functionality for Article

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticleController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticleController.java
@@ -80,17 +80,17 @@ public class ArticleController extends ApiController {
         return savedArticle;
     }
 
-    // @ApiOperation(value = "Delete an Article")
-    // @PreAuthorize("hasRole('ROLE_ADMIN')")
-    // @DeleteMapping("")
-    // public Object deleteArticle(
-    //         @ApiParam("id") @RequestParam Long id) {
-    //     Article art = articleRepo.findById(id)
-    //             .orElseThrow(() -> new EntityNotFoundException(Article.class, id));
+    @ApiOperation(value = "Delete an Article")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteArticle(
+            @ApiParam("id") @RequestParam Long id) {
+        Article art = articleRepo.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Article.class, id));
 
-    //     articleRepo.delete(art);
-    //     return genericMessage("Article with id %s deleted".formatted(id));
-    // }
+        articleRepo.delete(art);
+        return genericMessage("Article with id %s deleted".formatted(id));
+    }
 
     @ApiOperation(value = "Update a single Article")
     @PreAuthorize("hasRole('ROLE_ADMIN')")

--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticleController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticleController.java
@@ -92,24 +92,24 @@ public class ArticleController extends ApiController {
     //     return genericMessage("Article with id %s deleted".formatted(id));
     // }
 
-    // @ApiOperation(value = "Update a single Article")
-    // @PreAuthorize("hasRole('ROLE_ADMIN')")
-    // @PutMapping("")
-    // public Article updateArticle(
-    //         @ApiParam("id") @RequestParam Long id,
-    //         @RequestBody @Valid Article incoming) {
+    @ApiOperation(value = "Update a single Article")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public Article updateArticle(
+            @ApiParam("id") @RequestParam Long id,
+            @RequestBody @Valid Article incoming) {
 
-    //     Article art = articleRepo.findById(id)
-    //             .orElseThrow(() -> new EntityNotFoundException(Article.class, id));
+        Article art = articleRepo.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Article.class, id));
 
-    //     art.setTitle(incoming.getTitle());
-    //     art.setUrl(incoming.getUrl());
-    //     art.setExplanation(incoming.getExplanation());
-    //     art.setEmail(incoming.getEmail());
-    //     art.setDateAdded(incoming.getDateAdded());
+        art.setTitle(incoming.getTitle());
+        art.setUrl(incoming.getUrl());
+        art.setExplanation(incoming.getExplanation());
+        art.setEmail(incoming.getEmail());
+        art.setDateAdded(incoming.getDateAdded());
 
-    //     articleRepo.save(art);
+        articleRepo.save(art);
 
-    //     return art;
-    // }
+        return art;
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticleControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticleControllerTests.java
@@ -253,83 +253,83 @@ public class ArticleControllerTests extends ControllerTestCase {
         //         assertEquals("Article with id 15 not found", json.get("message"));
         // }
 
-        // @WithMockUser(roles = { "ADMIN", "USER" })
-        // @Test
-        // public void admin_can_edit_an_existing_article() throws Exception {
-        //         // arrange
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_article() throws Exception {
+                // arrange
 
-        //         LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
-        //         LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+                LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
 
-        //         Article articleOrig = Article.builder()
-        //                         .title("topTenFoods")
-        //                         .url("www.google.com")
-        //                         .explanation("bestFood")
-        //                         .email("nwenstad@ucsb.edu")
-        //                         .dateAdded(ldt1)
-        //                         .build();
+                Article articleOrig = Article.builder()
+                                .title("topTenFoods")
+                                .url("www.google.com")
+                                .explanation("bestFood")
+                                .email("nwenstad@ucsb.edu")
+                                .dateAdded(ldt1)
+                                .build();
 
-        //         Article articleEdited = Article.builder()
-        //                         .title("bottomTenFoods")
-        //                         .url("www.bing.com")
-        //                         .explanation("worstFood")
-        //                         .email("nwenstad@ucsb.edu")
-        //                         .dateAdded(ldt2)
-        //                         .build();
+                Article articleEdited = Article.builder()
+                                .title("bottomTenFoods")
+                                .url("www.bing.com")
+                                .explanation("worstFood")
+                                .email("nwenstad@ucsb.edu")
+                                .dateAdded(ldt2)
+                                .build();
 
-        //         String requestBody = mapper.writeValueAsString(articleEdited);
+                String requestBody = mapper.writeValueAsString(articleEdited);
 
-        //         when(articleRepo.findById(eq(67L))).thenReturn(Optional.of(articleOrig));
+                when(articleRepo.findById(eq(67L))).thenReturn(Optional.of(articleOrig));
 
-        //         // act
-        //         MvcResult response = mockMvc.perform(
-        //                         put("/api/article?id=67")
-        //                                         .contentType(MediaType.APPLICATION_JSON)
-        //                                         .characterEncoding("utf-8")
-        //                                         .content(requestBody)
-        //                                         .with(csrf()))
-        //                         .andExpect(status().isOk()).andReturn();
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/article?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
 
-        //         // assert
-        //         verify(articleRepo, times(1)).findById(67L);
-        //         verify(articleRepo, times(1)).save(articleEdited); // should be saved with correct user
-        //         String responseString = response.getResponse().getContentAsString();
-        //         assertEquals(requestBody, responseString);
-        // }
+                // assert
+                verify(articleRepo, times(1)).findById(67L);
+                verify(articleRepo, times(1)).save(articleEdited); // should be saved with correct user
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
 
-//         @WithMockUser(roles = { "ADMIN", "USER" })
-//         @Test
-//         public void admin_cannot_edit_article_that_does_not_exist() throws Exception {
-//                 // arrange
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_article_that_does_not_exist() throws Exception {
+                // arrange
 
-//                 LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
 
-//                 Article articleEdited1 = Article.builder()
-//                                 .title("topTenFoods")
-//                                 .url("www.google.com")
-//                                 .explanation("bestFood")
-//                                 .email("nwenstad@ucsb.edu")
-//                                 .dateAdded(ldt1)
-//                                 .build();
+                Article articleEdited1 = Article.builder()
+                                .title("topTenFoods")
+                                .url("www.google.com")
+                                .explanation("bestFood")
+                                .email("nwenstad@ucsb.edu")
+                                .dateAdded(ldt1)
+                                .build();
 
-//                 String requestBody = mapper.writeValueAsString(articleEdited1);
+                String requestBody = mapper.writeValueAsString(articleEdited1);
 
-//                 when(articleRepo.findById(eq(67L))).thenReturn(Optional.empty());
+                when(articleRepo.findById(eq(67L))).thenReturn(Optional.empty());
 
-//                 // act
-//                 MvcResult response = mockMvc.perform(
-//                                 put("/api/article?id=67")
-//                                                 .contentType(MediaType.APPLICATION_JSON)
-//                                                 .characterEncoding("utf-8")
-//                                                 .content(requestBody)
-//                                                 .with(csrf()))
-//                                 .andExpect(status().isNotFound()).andReturn();
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/article?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
 
-//                 // assert
-//                 verify(articleRepo, times(1)).findById(67L);
-//                 Map<String, Object> json = responseToJson(response);
-//                 assertEquals("Article with id 67 not found", json.get("message"));
+                // assert
+                verify(articleRepo, times(1)).findById(67L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Article with id 67 not found", json.get("message"));
 
-//         }
+        }
 
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticleControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticleControllerTests.java
@@ -202,56 +202,56 @@ public class ArticleControllerTests extends ControllerTestCase {
                 assertEquals(expectedJson, responseString);
         }
 
-        // @WithMockUser(roles = { "ADMIN", "USER" })
-        // @Test
-        // public void admin_can_delete_a_article() throws Exception {
-        //         // arrange
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_a_article() throws Exception {
+                // arrange
 
-        //         LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
 
-        //         Article art1 = Article.builder()
-        //                         .title("topTenFoods")
-        //                         .url("www.google.com")
-        //                         .explanation("bestFood")
-        //                         .email("nwenstad@ucsb.edu")
-        //                         .dateAdded(ldt1)
-        //                         .build();
+                Article art1 = Article.builder()
+                                .title("topTenFoods")
+                                .url("www.google.com")
+                                .explanation("bestFood")
+                                .email("nwenstad@ucsb.edu")
+                                .dateAdded(ldt1)
+                                .build();
 
-        //         when(articleRepo.findById(eq(15L))).thenReturn(Optional.of(art1));
+                when(articleRepo.findById(eq(15L))).thenReturn(Optional.of(art1));
 
-        //         // act
-        //         MvcResult response = mockMvc.perform(
-        //                         delete("/api/article?id=15")
-        //                                         .with(csrf()))
-        //                         .andExpect(status().isOk()).andReturn();
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/article?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
 
-        //         // assert
-        //         verify(articleRepo, times(1)).findById(15L);
-        //         verify(articleRepo, times(1)).delete(any());
+                // assert
+                verify(articleRepo, times(1)).findById(15L);
+                verify(articleRepo, times(1)).delete(any());
 
-        //         Map<String, Object> json = responseToJson(response);
-        //         assertEquals("Article with id 15 deleted", json.get("message"));
-        // }
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Article with id 15 deleted", json.get("message"));
+        }
 
-        // @WithMockUser(roles = { "ADMIN", "USER" })
-        // @Test
-        // public void admin_tries_to_delete_non_existant_article_and_gets_right_error_message()
-        //                 throws Exception {
-        //         // arrange
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_article_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
 
-        //         when(articleRepo.findById(eq(15L))).thenReturn(Optional.empty());
+                when(articleRepo.findById(eq(15L))).thenReturn(Optional.empty());
 
-        //         // act
-        //         MvcResult response = mockMvc.perform(
-        //                         delete("/api/article?id=15")
-        //                                         .with(csrf()))
-        //                         .andExpect(status().isNotFound()).andReturn();
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/article?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
 
-        //         // assert
-        //         verify(articleRepo, times(1)).findById(15L);
-        //         Map<String, Object> json = responseToJson(response);
-        //         assertEquals("Article with id 15 not found", json.get("message"));
-        // }
+                // assert
+                verify(articleRepo, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Article with id 15 not found", json.get("message"));
+        }
 
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticleControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticleControllerTests.java
@@ -151,7 +151,7 @@ public class ArticleControllerTests extends ControllerTestCase {
                                 .title("bottomTenFoods")
                                 .url("www.bing.com")
                                 .explanation("worstFood")
-                                .email("nwenstad@ucsb.edu")
+                                .email("nwenstad@umail.ucsb.edu")
                                 .dateAdded(ldt2)
                                 .build();
 
@@ -273,7 +273,7 @@ public class ArticleControllerTests extends ControllerTestCase {
                                 .title("bottomTenFoods")
                                 .url("www.bing.com")
                                 .explanation("worstFood")
-                                .email("nwenstad@ucsb.edu")
+                                .email("nwenstad@umail.ucsb.edu")
                                 .dateAdded(ldt2)
                                 .build();
 


### PR DESCRIPTION
# Overview

I added the PUT and DELETE functionality to update a single article. A user can now edit an article and delete and article, assuming they are an admin. This finished up the Article entity

# Issues Addressed

This PR addresses issue #3 

# Details

I followed the examples of the GET and POST endpoints to create a PUT and DELETE endpoint. Everything is working locally and on heroku.

# Test Plan (for interactive testing)

To test this, pull the branch and run using 'npm start' in the frontend directory and "mvn spring-boot:run" in the parent directory. From there, you should be able to locate the swagger ui and test the functionality of the method.
