### PR TITLE
hm - added delete endpoint and tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -78,6 +78,18 @@ public class MenuItemReviewController extends ApiController {
         return savedReview;
     }
 
+    @ApiOperation(value = "Delete a MenuItemReview")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteMenuItemReview(
+            @ApiParam("id") @RequestParam Long id) {
+        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+        menuItemReviewRepository.delete(menuItemReview);
+        return genericMessage("MenuItemReview with id %s deleted".formatted(id));
+    }
+
     @ApiOperation(value = "Update (edit) a single menu item review")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PutMapping("")

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -202,6 +202,57 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
                 assertEquals(expectedJson, responseString);
         }
 
+                @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_a_date() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                MenuItemReview review1 = MenuItemReview.builder()
+                                .itemId(101)
+                                .reviewerEmail("huntermassey@umail.ucsb.edu")
+                                .stars(3)
+                                .dateReviewed(ldt1)  
+                                .comments("It was aight.")
+                                .build();
+
+                when(menuItemReviewRepository.findById(eq(15L))).thenReturn(Optional.of(review1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/MenuItemReview?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(menuItemReviewRepository, times(1)).findById(15L);
+                verify(menuItemReviewRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("MenuItemReview with id 15 deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_menuitemreview_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(menuItemReviewRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/MenuItemReview?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(menuItemReviewRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("MenuItemReview with id 15 not found", json.get("message"));
+        }
+
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
         public void admin_can_edit_an_existing_menuitemreview() throws Exception {


### PR DESCRIPTION
# Overview

Added DELETE endpoint functionality and tests with 100% coverage.

# Issues Addressed

Addresses issue #12 

# Details

Deleting an existing review:
![Screenshot 2022-05-03 184215](https://user-images.githubusercontent.com/77125370/166612959-d933000e-6e53-454e-b037-7e90502c9f44.png)

Attempting to delete a non-existant review:
![Screenshot 2022-05-03 184232](https://user-images.githubusercontent.com/77125370/166612968-8920398f-56de-401d-a0b4-35951f1c30c3.png)

